### PR TITLE
add chainrules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,23 @@
 name = "FastChebInterp"
 uuid = "cf66c380-9a80-432c-aff8-4f9c79c0bdde"
-version = "1.0"
+version = "1.1"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 
 [compat]
+ChainRulesCore = "1"
+ChainRulesTestUtils = "1"
 FFTW = "1.0"
 StaticArrays = "0.12, 1.0"
 julia = "1.3"
 
 [extras]
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["ChainRulesTestUtils", "Random", "Test"]

--- a/src/FastChebInterp.jl
+++ b/src/FastChebInterp.jl
@@ -34,7 +34,7 @@ A multidimensional Chebyshev-polynomial interpolation object.
 Given a `c::ChebPoly`, you can evaluate it at a point `x`
 with `c(x)`, where `x` is a vector (or a scalar if `c` is 1d).
 """
-struct ChebPoly{N,T,Td<:Real}
+struct ChebPoly{N,T,Td<:Real} <: Function
     coefs::Array{T,N} # chebyshev coefficients
     lb::SVector{N,Td} # lower/upper bounds
     ub::SVector{N,Td} #    of the domain
@@ -48,9 +48,11 @@ function Base.show(io::IO, c::ChebPoly)
     end
 end
 Base.ndims(c::ChebPoly) = ndims(c.coefs)
+Base.zero(c::ChebPoly{N,T,Td}) where {N,T,Td} = ChebPoly{N,T,Td}(zero(c.coefs), c.lb, c.ub)
 
 include("interp.jl")
 include("regression.jl")
 include("eval.jl")
+include("chainrules.jl")
 
 end # module

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,0 +1,39 @@
+import ChainRulesCore
+using ChainRulesCore: ProjectTo, NoTangent, @not_implemented
+
+function ChainRulesCore.rrule(c::ChebPoly{1}, x::Real)
+    project_x = ProjectTo(x)
+    y, ∇y = chebgradient(c, x)
+    chebpoly_pullback(∂y) = @not_implemented("no rrule for changes in ChebPoly itself"), project_x(real(∇y' * ∂y))
+    y, chebpoly_pullback
+end
+
+function ChainRulesCore.rrule(c::ChebPoly, x::AbstractVector{<:Real})
+    project_x = ProjectTo(x)
+    y, J = chebjacobian(c, x)
+    chebpoly_pullback(Δy) = @not_implemented("no rrule for changes in ChebPoly itself"), project_x(vec(real(J' * Δy)))
+    y, chebpoly_pullback
+end
+
+ChainRulesCore.frule((Δself, Δx), c::ChebPoly{1}, x::Real) =
+    ChainRulesCore.frule((Δself, SVector{1}(Δx)), c, SVector{1}(x))
+
+function ChainRulesCore.frule((Δself, Δx), c::ChebPoly, x::AbstractVector)
+    y, J = chebjacobian(c, x)
+    if Δself isa ChainRulesCore.AbstractZero # Δself == 0
+        Δy = J * Δx
+        return y, y isa Number ? Δy[1] : Δy
+    else # need derivatives with respect to changes in c
+        # additional Δx from changes in bound:
+        # --- recall x0 = @. (x - c.lb) * 2 / (c.ub - c.lb) - 1,
+        #     but note that J already includes 2 / (c.ub - c.lb)
+        d2 = @. (x - c.lb) / (c.ub - c.lb)
+        Δx′ = @. Δx + (d2 - 1) * Δself.lb - d2 * Δself.ub
+        Δy = J * Δx′
+
+        # dependence on coefs is linear
+        Δcoefs = typeof(c)(Δself.coefs, c.lb, c.ub)
+
+        return y, (y isa Number ? Δy[1] : Δy) + Δcoefs(x)
+    end
+end


### PR DESCRIPTION
Fixes #8, adding both a forward `frule` and a reverse `rrule` for `ChebPoly` evaluation.

Note that for the `rrule`, we don't yet support propagating derivatives through to changes in the `ChebPoly` object itself.   It seems like this would involve allocating huge `Tangent` objects for something that is rarely needed, so I marked it as `@notimplemented` instead.  (@gaurav-arya, do you know a way to do this only when it is desired?)

Nor do we yet have rules for differentiating the `ChebPoly` constructor functions (e.g. if you want to compute sensitivity of the polynomial outputs to the *data* used to construct the polynomial).   In principle, this should be straightforward since the polynomial construction is linear in the data.